### PR TITLE
adding separate DevOnly blocks

### DIFF
--- a/Layouts/healthcare.yaml
+++ b/Layouts/healthcare.yaml
@@ -454,7 +454,9 @@ cards:
             type: numeric
             tooltip: Total number of mechanical ventilation beds
 
-# not live
+# {{ EndDevOnlyBlock }}
+
+# {{ StartDevOnlyBlock }}
 # Only really required before we had the localisation feature working, to present nation 
 # figures as in the No 10 slides - try rates
 
@@ -496,7 +498,9 @@ cards:
             type: numeric
             tooltip: Number of COVID-19 patients currently in mechanical ventilation beds
 
-# not live
+# {{ EndDevOnlyBlock }}
+
+# {{ StartDevOnlyBlock }}
 # Not currently publishing patients discharged: needs discussion with NHS to agree definitions.
 # We don't currently pull in the data from the DAs on this - they did agree to provide it when
 # asked by the No 10 Press data team, but we have never finalised it
@@ -654,6 +658,9 @@ cards:
             type: numeric
             tooltip: COVID-19 discharges per 100,000 resident population
 
+# {{ EndDevOnlyBlock }}
+
+# {{ StartDevOnlyBlock }}
 # not live - probably worth adding
 
   # - heading: Healthcare data by area
@@ -661,4 +668,6 @@ cards:
   #   fullWidth: true
   #   download:
   #     - TBC
+
+# {{ EndDevOnlyBlock }}
   


### PR DESCRIPTION
Separated out DevOnly blocks so that each one can be enabled without risking enabling another