### PR TITLE
Update copy to use singular 'data' rather than plural per gov.uk style guide

### DIFF
--- a/Layouts/Changes/changeLog.yaml
+++ b/Layouts/Changes/changeLog.yaml
@@ -102,7 +102,7 @@ changeLog:
     relativeUrl: /details/download
     headline: MSOA data have been added to the downloads page.
     body: > 
-      Area types in the download page now include MSOAs. The data are now available for 
+      Area types in the download page now include MSOAs. The data is now available for 
       download by region, local authority, a single MSOA, or the full dataset. Downloaded 
       conetnts will also include information on region and local authority as well as MSOA. 
 

--- a/Layouts/cases.yaml
+++ b/Layouts/cases.yaml
@@ -717,7 +717,7 @@ cards:
     abstract: >
       Number of people with at least one positive, negative or void COVID-19 test result (either lab-reported or lateral flow device). 
       Initially only NHS and, in England, PHE tests were included but commercial tests have been included from   
-      different dates between 15th June and 14th July for each nation.  National data are not directly comparable.
+      different dates between 15th June and 14th July for each nation.  National data is not directly comparable.
 
     download:
       - newCasesBySpecimenDate

--- a/Layouts/deaths.yaml
+++ b/Layouts/deaths.yaml
@@ -757,8 +757,8 @@ cards:
     fullWidth: true
     abstract: > 
       Number of deaths of people whose death certificate mentioned COVID-19 as one of the causes.
-      The data are published weekly by the ONS, NRS and NISRA and there is a lag in reporting of 
-      at least 11 days because the data are based on death registrations.
+      The data is published weekly by the ONS, NRS and NISRA and there is a lag in reporting of 
+      at least 11 days because the data is based on death registrations.
     
     download:
       - newOnsDeathsByRegistrationDate
@@ -822,8 +822,8 @@ cards:
     fullWidth: true
     abstract: > 
       Number of care home deaths where the death certificate mentioned COVID-19 as one of the causes.
-      The data are published weekly by the ONS, NRS and NISRA and there is a lag in reporting of 
-      at least 11 days because the data are based on death registrations.
+      The data is published weekly by the ONS, NRS and NISRA and there is a lag in reporting of 
+      at least 11 days because the data is based on death registrations.
     
     download:
       - newOnsCareHomeDeathsByRegistrationDate
@@ -1174,8 +1174,8 @@ cards:
     fullWidth: false
     abstract: >
       Total number of deaths since the start of the pandemic of people whose death certificate mentioned
-      COVID-19 as one of the causes. The data are published weekly by the ONS, NRS and NISRA and there is 
-      a lag in reporting of at least 11 days because the data are based on death registrations. Only data 
+      COVID-19 as one of the causes. The data is published weekly by the ONS, NRS and NISRA and there is 
+      a lag in reporting of at least 11 days because the data is based on death registrations. Only data 
       available for the latest reported date are shown. 
 
     download:
@@ -1748,8 +1748,8 @@ cards:
     fullWidth: true
     abstract: > 
       Number of deaths of people whose death certificate mentioned COVID-19 as one of the causes.
-      The data are published weekly by the ONS, NRS and NISRA and there is a lag in reporting of 
-      at least 11 days because the data are based on death registrations.
+      The data is published weekly by the ONS, NRS and NISRA and there is a lag in reporting of 
+      at least 11 days because the data is based on death registrations.
     
     download:
       - newWeeklyNsoDeathsByRegDate
@@ -1815,8 +1815,8 @@ cards:
     fullWidth: true
     abstract: > 
       Number of care home deaths where the death certificate mentioned COVID-19 as one of the causes.
-      The data are published weekly by the ONS, NRS and NISRA and there is a lag in reporting of 
-      at least 11 days because the data are based on death registrations.
+      The data is published weekly by the ONS, NRS and NISRA and there is a lag in reporting of 
+      at least 11 days because the data is based on death registrations.
     
     download:
       - newWeeklyNsoCareHomeDeathsByRegDate

--- a/Layouts/healthcare.yaml
+++ b/Layouts/healthcare.yaml
@@ -67,7 +67,7 @@ cards:
       
     fullWidth: true
     abstract: >
-      Daily and cumulative numbers of COVID-19 patients admitted to hospital. Data are not
+      Daily and cumulative numbers of COVID-19 patients admitted to hospital. Data is not
       updated every day by all four nations and the figures for Wales are not comparable to those
       for other nations as Wales include suspected COVID-19 patients while the other nations include 
       only confirmed cases.
@@ -143,7 +143,7 @@ cards:
 
     fullWidth: true
     abstract: >
-      Daily and cumulative numbers of COVID-19 patients admitted to hospital. Data are not
+      Daily and cumulative numbers of COVID-19 patients admitted to hospital. Data is not
       updated every day by all four nations and the figures are not comparable as Wales
       include suspected COVID-19 patients while the other nations include only confirmed
       cases.
@@ -307,7 +307,7 @@ cards:
     fullWidth: true
     abstract: >
       Rate of COVID-19 patients admitted to hospital in the rolling 7-day period ending
-      on the dates shown. Data are not
+      on the dates shown. Data is not
       updated every day by all four nations and the figures are not comparable as Wales
       include suspected COVID-19 patients while the other nations include only confirmed
       cases.
@@ -360,7 +360,7 @@ cards:
     fullWidth: false
     abstract: >
       Total numbers of COVID-19 patients admitted to hospital since the start of the pandemic, by
-      age. Data are not updated every day. Some admission records have missing age, so the sum of
+      age. Data is not updated every day. Some admission records have missing age, so the sum of
       the subgroups does not equal the total admissions for the area.
       
     download:
@@ -490,7 +490,7 @@ cards:
       
     fullWidth: true
     abstract: >
-      Daily count of confirmed COVID-19 patients in hospital at 8am. Data are not updated every day.
+      Daily count of confirmed COVID-19 patients in hospital at 8am. Data is not updated every day.
      
     download:
       - hospitalCases
@@ -551,9 +551,9 @@ cards:
     abstract: >
       Daily count of confirmed COVID-19 patients in hospital at 8am.
       Data from the four nations may not be directly comparable as data about COVID-19
-      patients in hospitals are collected differently. Data are not reported by each nation
+      patients in hospitals are collected differently. Data is not reported by each nation
       every day. The UK figure is the sum of the four nations' figures and can only be
-      calculated when all nations' data are available.
+      calculated when all nations' data is available.
 
     download:
       - hospitalCases
@@ -672,7 +672,7 @@ cards:
   #   fullWidth: true
   #   abstract: >
   #     Daily count of confirmed COVID-19 patients in hospital at midnight the preceding
-  #     night in each NHS region. Data are not updated every day.
+  #     night in each NHS region. Data is not updated every day.
 
   #   download:
   #     - hospitalCases
@@ -729,7 +729,7 @@ cards:
           - overview
       
     abstract: >
-      Daily count of COVID-19 patients in mechanical ventilation beds. Data are not updated
+      Daily count of COVID-19 patients in mechanical ventilation beds. Data is not updated
       every day.
 
     download:
@@ -841,9 +841,9 @@ cards:
     abstract: >
       COVID-19 patients in mechanical ventilation beds. Data from the four nations may not be
       directly comparable as data about COVID-19 patients in hospitals are collected differently. Data
-      are not reported by each nation every day and England data are not available before 2 April. The
+      are not reported by each nation every day and England data is not available before 2 April. The
       UK figure is the sum of the four nations' figures and can only be calculated when all nations'
-      data are available.
+      data is available.
 
     download:
       - covidOccupiedMVBeds
@@ -959,9 +959,9 @@ cards:
     abstract: >
       Mechanical ventilation bed occupany by occupant type. Data from the four nations may not be
       directly comparable as data about COVID-19 patients in hospitals are collected differently. Data
-      are not reported by each nation every day and England data are not available before 2 April. The
+      are not reported by each nation every day and England data is not available before 2 April. The
       UK figure is the sum of the four nations' figures and can only be calculated when all nations'
-      data are available.
+      data is available.
 
     download:
       - covidOccupiedMVBeds


### PR DESCRIPTION
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style

> **data**
> Treat as a singular noun: The data is stored on a secure server.